### PR TITLE
Pause Menu Test Level

### DIFF
--- a/menus/pause_menu/pause_opener.gd
+++ b/menus/pause_menu/pause_opener.gd
@@ -1,0 +1,19 @@
+extends Control
+
+var is_paused: bool = false
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	#if is_paused is false and escaped is pressed, creates the pause menu, sets is_paused to true
+	#this requires in the pause script that once the pause scene no longer active, that the bool returns false
+	#It may also require, that the pause is changed so that when it is disabled, that it destroys itself
+	
+	
+	if Input.is_action_just_pressed("pause") and not is_paused:
+		var pausescreen = load("res://menus/pause_menu/pause_menu_scene.tscn").instantiate()
+		add_child(pausescreen)
+		is_paused = true
+		
+		
+	pass

--- a/menus/pause_menu/pause_script.gd
+++ b/menus/pause_menu/pause_script.gd
@@ -1,6 +1,8 @@
 extends Control
 
 func _process(_delta: float) -> void:
+	#Checks if the player just pressed the input action labeled "pause" 
+	#(which is usually defined in the Input Map in Project Settings)
 	if Input.is_action_just_pressed("pause"):
 		$PauseContainer.visible = get_tree().paused;
 		get_tree().paused = not get_tree().paused;

--- a/test_scenes/playerTest_scene.tscn
+++ b/test_scenes/playerTest_scene.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=3 uid="uid://by4rqbp033pmb"]
+
+[ext_resource type="PackedScene" uid="uid://cx06e1lqkpenc" path="res://free_roam/player/player.tscn" id="1_4wa0d"]
+[ext_resource type="Script" path="res://menus/pause_menu/pause_opener.gd" id="2_24jda"]
+
+[node name="Node2D" type="Node2D"]
+
+[node name="Path2D" parent="." instance=ExtResource("1_4wa0d")]
+position = Vector2(465, 307)
+
+[node name="Control" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+script = ExtResource("2_24jda")


### PR DESCRIPTION
created a test scene where you can press the escape key to trigger the pause menu.

Please note, there will be some compatability issues with how the pause menu itself functions as it instantiates the menu, and leaving the pause menu does not destroy it