### PR TITLE
View only Recipe Book in Free Roam

### DIFF
--- a/free_roam/world/free_roam_base.tscn
+++ b/free_roam/world/free_roam_base.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=5 format=3 uid="uid://docgr3runo3a"]
+[gd_scene load_steps=6 format=3 uid="uid://docgr3runo3a"]
 
 [ext_resource type="PackedScene" uid="uid://cx06e1lqkpenc" path="res://free_roam/player/player.tscn" id="1_8gurn"]
 [ext_resource type="Script" path="res://menus/pause_menu/pause_opener.gd" id="2_7hu1x"]
 [ext_resource type="Script" path="res://free_roam/world/free_roam_camera.gd" id="2_y05i1"]
 [ext_resource type="PackedScene" uid="uid://dktieicdug37m" path="res://menus/phone/phone_ui.tscn" id="4_0axhq"]
+[ext_resource type="Script" path="res://menus/recipe_book/recipe_book_opener.gd" id="4_yfy7n"]
 
 [node name="FreeRoamBase" type="Node2D"]
 
@@ -17,6 +18,9 @@ script = ExtResource("2_y05i1")
 
 [node name="PauseOpener" type="Node" parent="."]
 script = ExtResource("2_7hu1x")
+
+[node name="RecipeBookOpener" type="Node" parent="."]
+script = ExtResource("4_yfy7n")
 
 [node name="UI" type="CanvasLayer" parent="."]
 

--- a/menus/phone/phone_ui.tscn
+++ b/menus/phone/phone_ui.tscn
@@ -104,6 +104,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 script = ExtResource("1_pyxwy")
 
 [node name="Panel" type="Panel" parent="."]
@@ -113,6 +114,7 @@ offset_top = 611.0
 offset_right = 1124.0
 offset_bottom = 936.0
 rotation = -0.0915635
+mouse_filter = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_liewr")
 
 [node name="MarginContainer" type="MarginContainer" parent="Panel"]

--- a/menus/recipe_book/recipe_book.gd
+++ b/menus/recipe_book/recipe_book.gd
@@ -22,12 +22,18 @@ var selected_recipes: Array[int] = [] ## List of indices that have been selected
 signal recipes_selected(variants: Array[RecipeVariant])
 
 func _ready() -> void:
+	get_tree().paused = true # this is reset to false in _on_tree_exiting
+	MainMusicPlayer.set_volume(0.3)
 	update_displayed_recipes()
 	
 	if not allow_baking:
 		bake_left.visible = false
 		bake_right.visible = false
 		baking_text.visible = false
+
+func _process(delta: float) -> void:
+	if Input.is_action_just_pressed("pause") || Input.is_action_just_pressed("open_recipes"):
+		queue_free()
 
 func update_displayed_recipes() -> void:
 	var left_idx = current_page*2
@@ -80,3 +86,6 @@ func _on_finish_button_pressed() -> void:
 	
 	# TODO: Move this to the new variant selection menu?
 	#
+func _on_tree_exiting() -> void:
+	get_tree().paused = false
+	MainMusicPlayer.set_volume(1.0)

--- a/menus/recipe_book/recipe_book.tscn
+++ b/menus/recipe_book/recipe_book.tscn
@@ -356,6 +356,7 @@ region_rect = Rect2(26, 61, 252, 167)
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_upkg4"]
 
 [node name="RecipeBook" type="CanvasLayer"]
+process_mode = 3
 script = ExtResource("1_3psjk")
 recipes = Array[ExtResource("2_8r5qq")]([SubResource("Resource_oqry2"), SubResource("Resource_d3qea"), SubResource("Resource_82m3y"), SubResource("Resource_piyw4"), SubResource("Resource_bcias"), SubResource("Resource_2j335"), SubResource("Resource_mbxs7"), SubResource("Resource_152om"), SubResource("Resource_jy2si"), SubResource("Resource_nt2kn"), SubResource("Resource_2l5fl"), SubResource("Resource_36ugh")])
 
@@ -455,6 +456,7 @@ script = ExtResource("10_7f2te")
 
 [node name="BakeLeft" type="Button" parent="."]
 unique_name_in_owner = true
+z_index = 1
 anchors_preset = 3
 anchor_left = 1.0
 anchor_top = 1.0
@@ -530,6 +532,7 @@ script = ExtResource("10_7f2te")
 [node name="RecipeVariantSelection" type="ColorRect" parent="."]
 unique_name_in_owner = true
 visible = false
+z_index = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -612,6 +615,7 @@ offset_bottom = 573.0
 [node name="VariantButton2" parent="RecipeVariantSelection/VariantsRight" instance=ExtResource("28_8q60k")]
 layout_mode = 2
 
+[connection signal="tree_exiting" from="." to="." method="_on_tree_exiting"]
 [connection signal="pressed" from="BakingText/FinishButton" to="." method="_on_finish_button_pressed"]
 [connection signal="pressed" from="BakeLeft" to="." method="_on_bake_left_pressed"]
 [connection signal="pressed" from="TurnPageRight" to="." method="_on_turn_page_right_pressed"]

--- a/menus/recipe_book/recipe_book_opener.gd
+++ b/menus/recipe_book/recipe_book_opener.gd
@@ -1,0 +1,10 @@
+extends Node
+
+var recipe_book: Node = null
+
+func _process(_delta: float) -> void:
+	if recipe_book != null: return # while the book menu is open, wait for it to close (free) itself
+	
+	if Input.is_action_just_pressed("open_recipes"):
+		recipe_book = load("res://menus/recipe_book/recipe_book_view_only.tscn").instantiate()
+		add_child(recipe_book)

--- a/menus/recipe_book/recipe_book_view_only.tscn
+++ b/menus/recipe_book/recipe_book_view_only.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=2 format=3 uid="uid://ddaktmmuf27ak"]
+
+[ext_resource type="PackedScene" uid="uid://c001by107vn8g" path="res://menus/recipe_book/recipe_book.tscn" id="1_gpdym"]
+
+[node name="RecipeBook" instance=ExtResource("1_gpdym")]
+
+[node name="FinishButton" parent="BakingText" index="1"]
+visible = false
+
+[node name="BakeLeft" parent="." index="5"]
+visible = false
+
+[node name="BakeRight" parent="." index="8"]
+visible = false


### PR DESCRIPTION
The recipe book can now be accessed in any of the free roam areas. The way opening the book works is similar to how PauseOpener works. A view only version of the recipe book with the buttons hidden was created (it's an extended scene). The phone UI was occluding mouse inputs, so some of the control nodes in the phone UI had their mouse input set to ignore.